### PR TITLE
added ftype support in resample

### DIFF
--- a/sh/resampled_raster_ts
+++ b/sh/resampled_raster_ts
@@ -40,6 +40,7 @@ copy (
 	  SELECT * 
 	  FROM  dh_feature
 	  WHERE hydrocode = :'hydrocode'
+          AND ftype = :'ftype'
 	),
 	metUnion as (
 		Select met.featureid, met.tstime, met.tsendtime,


### PR DESCRIPTION
This fixes the duplicate data bug in the resample raster method, but that bug still exists in other raster creation methods, as those methods do not have the ftype passed in as argument, and we definitely need to do that.  @COBrogan 

See #99 